### PR TITLE
Redesign profile README: in-repo animated SVGs + Action-generated stats

### DIFF
--- a/.github/workflows/blog-post-workflow.yml
+++ b/.github/workflows/blog-post-workflow.yml
@@ -1,14 +1,26 @@
 name: Latest blog post workflow
-on: 
-    schedule:
-        - cron: '0 * * * *'
-jobs: 
-    update-readme-with-blog: 
-        name: Update this repo's README with latest blog posts
-        runs-on: ubuntu-latest
-        steps: 
-            - uses: actions/checkout@v2
-            - uses: gautamkrishnar/blog-post-workflow@master
-              with: 
-                max_post_count: "4"
-                feed_list: "https://medium.com/feed/@brhnme, https://www.brhn.me/rss"
+
+on:
+  schedule:
+    - cron: '0 * * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: readme-updates
+  cancel-in-progress: false
+
+jobs:
+  update-readme-with-blog:
+    name: Update this repo's README with latest blog posts
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: gautamkrishnar/blog-post-workflow@1.9.6
+        with:
+          max_post_count: "5"
+          feed_list: "https://medium.com/feed/@brhnme, https://www.brhn.me/rss"
+          template: "- **[$title]($url)** · <sub>$date</sub>$newline"
+          date_format: "mmm d, yyyy"

--- a/.github/workflows/profile-assets.yml
+++ b/.github/workflows/profile-assets.yml
@@ -1,0 +1,65 @@
+name: Generate profile assets
+
+on:
+  schedule:
+    - cron: '17 5 * * *' # daily, offset from the hourly blog job to avoid push races
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: readme-updates
+  cancel-in-progress: false
+
+jobs:
+  cards:
+    name: Render stats cards and commit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Stats card (dark)
+        uses: stats-organization/github-readme-stats-action@v2
+        with:
+          card: stats
+          options: username=brhn-me&show_icons=true&hide_border=true&theme=github_dark&bg_color=00000000&rank_icon=percentile
+          path: assets/stats-dark.svg
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Stats card (light)
+        uses: stats-organization/github-readme-stats-action@v2
+        with:
+          card: stats
+          options: username=brhn-me&show_icons=true&hide_border=true&bg_color=00000000&rank_icon=percentile
+          path: assets/stats-light.svg
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Top languages card (dark)
+        uses: stats-organization/github-readme-stats-action@v2
+        with:
+          card: top-langs
+          options: username=brhn-me&layout=compact&hide_border=true&theme=github_dark&bg_color=00000000&langs_count=8
+          path: assets/langs-dark.svg
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Top languages card (light)
+        uses: stats-organization/github-readme-stats-action@v2
+        with:
+          card: top-langs
+          options: username=brhn-me&layout=compact&hide_border=true&bg_color=00000000&langs_count=8
+          path: assets/langs-light.svg
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Commit refreshed cards
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add assets/stats-*.svg assets/langs-*.svg
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "chore: refresh profile stats cards"
+            git pull --rebase origin "${GITHUB_REF_NAME}"
+            git push
+          fi

--- a/README.md
+++ b/README.md
@@ -2,69 +2,104 @@
   brhn-me / README.md
   Curated GitHub profile landing page for github.com/brhn-me.
   Generated from app/about/profile.ts and app/projects/data/*.mdx in
-  the brhn.me workspace. See ./blog-post-workflow.yml for the blog
-  auto-injector that fills BLOG-POST-LIST below.
+  the brhn.me workspace.
+
+  All dynamic visuals are committed in-repo:
+  - assets/header-*.svg, taglines-*.svg, cards/*.svg, footer-*.svg are
+    hand-authored animated SVGs (SMIL).
+  - assets/stats-*.svg and langs-*.svg are regenerated daily by
+    .github/workflows/profile-assets.yml.
+  - The "Latest writing" list below is filled hourly by
+    .github/workflows/blog-post-workflow.yml.
+  Every image ships dark + light variants via <picture> tags.
 -->
 
 <p align="center">
   <a href="https://www.brhn.me">
-    <img src="https://capsule-render.vercel.app/api?type=waving&color=0:0d1117,100:1f6feb&height=230&section=header&text=%40brhn-me&fontSize=44&fontColor=ffffff&fontAlignY=38&desc=brhn.me%20%E2%80%94%20AI%20%E2%80%A2%20full-stack%20engineering%20%E2%80%A2%20distributed%20systems&descSize=14&descAlignY=58&animation=fadeIn" alt="brhn-me" />
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="assets/header-dark.svg" />
+      <img src="assets/header-light.svg" alt="@brhn-me — brhn.me — AI · full-stack engineering · distributed systems" width="100%" />
+    </picture>
   </a>
 </p>
 
 <p align="center">
   <a href="https://www.brhn.me"><img alt="portfolio" src="https://img.shields.io/badge/portfolio-brhn.me-0e75b6?style=flat-square&logo=safari&logoColor=white" /></a>
   <a href="https://linkedin.com/in/brhn-me"><img alt="linkedin" src="https://img.shields.io/badge/linkedin-brhn--me-0a66c2?style=flat-square&logo=linkedin&logoColor=white" /></a>
-  <img alt="profile views" src="https://komarev.com/ghpvc/?username=brhn-me&label=profile%20views&color=0e75b6&style=flat-square" />
+  <a href="https://medium.com/@brhnme"><img alt="medium" src="https://img.shields.io/badge/medium-%40brhnme-12100e?style=flat-square&logo=medium&logoColor=white" /></a>
 </p>
 
 <p align="center">
-  <a href="https://git.io/typing-svg">
-    <img src="https://readme-typing-svg.demolab.com?font=Fira+Code&weight=500&size=22&pause=1400&color=58a6ff&center=true&vCenter=true&width=820&lines=AI+%2B+Full-Stack+Software+Engineer;Currently%3A+agentic+AI+systems;Java+%2F+Spring+Boot+%C2%B7+Elasticsearch+%C2%B7+large-scale+data;Distributed+systems+%C2%B7+ML+pipelines+%C2%B7+NLP;Cross-platform+tooling+%C2%B7+desktop+%C2%B7+web;Just+a+curious+wanderer" alt="what I build" />
-  </a>
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="assets/taglines-dark.svg" />
+    <img src="assets/taglines-light.svg" alt="AI + Full-Stack Software Engineer" width="100%" />
+  </picture>
 </p>
 
----
-
-I work across **AI and full-stack software engineering**. Current primary focus is **agentic AI systems**. Day-to-day toolkit spans Java / Spring Boot microservices, Elasticsearch and large-scale data pipelines, applied ML and NLP, secure REST APIs and event-driven backends, distributed observability, and cross-platform clients (web, desktop, WebAssembly). I like systems that are reliable, well-instrumented, and pleasant to operate.
-
-The code here ranges from production-grade backend services to weekend research experiments. Everything I open-source lives below; longer write-ups live on [brhn.me](https://www.brhn.me).
+I work across **AI and full-stack software engineering**, with a current focus on **agentic AI systems**. My day-to-day toolkit spans Java / Spring Boot microservices, Elasticsearch and large-scale data pipelines, applied ML and NLP, and cross-platform clients (web, desktop, WebAssembly). The code here ranges from production-grade backend services to weekend research experiments; longer write-ups live on [brhn.me](https://www.brhn.me).
 
 ---
 
 ### 🛠 What I work with
 
-**Languages**
+<table>
+  <tr>
+    <td><b>Languages</b></td>
+    <td>
+      <picture>
+        <source media="(prefers-color-scheme: dark)" srcset="https://skillicons.dev/icons?i=java,python,go,ts,rust,bash&theme=dark" />
+        <img src="https://skillicons.dev/icons?i=java,python,go,ts,rust,bash&theme=light" alt="Java, Python, Go, TypeScript, Rust, Bash" height="40" />
+      </picture>
+    </td>
+  </tr>
+  <tr>
+    <td><b>AI / ML</b></td>
+    <td>
+      <picture>
+        <source media="(prefers-color-scheme: dark)" srcset="https://skillicons.dev/icons?i=pytorch,opencv,fastapi&theme=dark" />
+        <img src="https://skillicons.dev/icons?i=pytorch,opencv,fastapi&theme=light" alt="PyTorch, OpenCV, FastAPI" height="40" />
+      </picture>
+    </td>
+  </tr>
+  <tr>
+    <td><b>Backend &amp; distributed</b></td>
+    <td>
+      <picture>
+        <source media="(prefers-color-scheme: dark)" srcset="https://skillicons.dev/icons?i=spring,hibernate,kafka,redis,grafana,prometheus&theme=dark" />
+        <img src="https://skillicons.dev/icons?i=spring,hibernate,kafka,redis,grafana,prometheus&theme=light" alt="Spring, Hibernate, Kafka, Redis, Grafana, Prometheus" height="40" />
+      </picture>
+    </td>
+  </tr>
+  <tr>
+    <td><b>Frontend &amp; cross-platform</b></td>
+    <td>
+      <picture>
+        <source media="(prefers-color-scheme: dark)" srcset="https://skillicons.dev/icons?i=react,nextjs,tauri,wasm,tailwind&theme=dark" />
+        <img src="https://skillicons.dev/icons?i=react,nextjs,tauri,wasm,tailwind&theme=light" alt="React, Next.js, Tauri, WebAssembly, Tailwind" height="40" />
+      </picture>
+    </td>
+  </tr>
+  <tr>
+    <td><b>Data &amp; search</b></td>
+    <td>
+      <picture>
+        <source media="(prefers-color-scheme: dark)" srcset="https://skillicons.dev/icons?i=elasticsearch,postgres,mongodb&theme=dark" />
+        <img src="https://skillicons.dev/icons?i=elasticsearch,postgres,mongodb&theme=light" alt="Elasticsearch, PostgreSQL, MongoDB" height="40" />
+      </picture>
+    </td>
+  </tr>
+  <tr>
+    <td><b>Infra &amp; tooling</b></td>
+    <td>
+      <picture>
+        <source media="(prefers-color-scheme: dark)" srcset="https://skillicons.dev/icons?i=docker,aws,linux,git&theme=dark" />
+        <img src="https://skillicons.dev/icons?i=docker,aws,linux,git&theme=light" alt="Docker, AWS, Linux, Git" height="40" />
+      </picture>
+    </td>
+  </tr>
+</table>
 
-<a href="https://skillicons.dev"><img src="https://skillicons.dev/icons?i=java,python,go,ts,rust,bash" alt="languages" /></a>
-
-**AI / ML**
-
-<a href="https://skillicons.dev"><img src="https://skillicons.dev/icons?i=pytorch,fastapi,redis" alt="ai-ml" /></a>
-
-Agentic systems (current focus) · LLM agents · NLP · RAG · vector search · ONNX Runtime · Weights & Biases · multimodal models · edge inference
-
-**Backend & distributed systems**
-
-<a href="https://skillicons.dev"><img src="https://skillicons.dev/icons?i=spring,hibernate,fastapi,flask,redis,grafana,prometheus" alt="backend" /></a>
-
-Spring Boot · JPA / Hibernate · gRPC · WebSockets · event-driven architecture · microservices · REST APIs · OpenTelemetry
-
-**Frontend & cross-platform**
-
-<a href="https://skillicons.dev"><img src="https://skillicons.dev/icons?i=react,nextjs,vite,tauri,wasm,tailwind,angularjs" alt="frontend" /></a>
-
-**Infra & tooling**
-
-<a href="https://skillicons.dev"><img src="https://skillicons.dev/icons?i=docker,aws,linux,git,github" alt="infra" /></a>
-
-Loki · OpenShift · Linux sandboxing
-
-**Search & data**
-
-<a href="https://skillicons.dev"><img src="https://skillicons.dev/icons?i=elasticsearch,postgres,mysql,mongodb,kafka" alt="data" /></a>
-
-Elasticsearch (cluster ops, indexing pipelines) · Lucene · Hadoop · Spark · Apache Kafka
+<sub><em>Current focus: agentic AI systems — LLM agents, RAG, vector search, edge inference.</em></sub>
 
 ---
 
@@ -72,41 +107,35 @@ Elasticsearch (cluster ops, indexing pipelines) · Lucene · Hadoop · Spark · 
 
 <table>
   <tr>
-    <td width="33%" valign="top">
-      <h4>
-        <a href="https://www.brhn.me/projects/fotu">Fotu</a>
-      </h4>
-      <p><em>Photo Organization & Deduplication Suite</em></p>
-      <p>Multi-tool suite for managing large photo libraries: device sync with EXIF-based organization, multi-method deduplication (exact, perceptual, video, CNN), and a unified desktop app. Source files are <strong>never</strong> modified or deleted.</p>
-      <p>
-        <code>Python</code> · <code>Go</code> · <code>React</code> · <code>Tauri</code> · <code>Computer Vision</code>
-      </p>
+    <td width="33%" align="center" valign="top">
+      <a href="https://www.brhn.me/projects/fotu">
+        <picture>
+          <source media="(prefers-color-scheme: dark)" srcset="assets/cards/fotu-dark.svg" />
+          <img src="assets/cards/fotu-light.svg" alt="Fotu — photo organization and deduplication suite" width="100%" />
+        </picture>
+      </a>
       <p>
         <a href="https://github.com/brhn-me/fotu">→ Code</a> · <a href="https://www.brhn.me/projects/fotu">→ Details</a>
       </p>
     </td>
-    <td width="33%" valign="top">
-      <h4>
-        <a href="https://www.brhn.me/projects/likhon">Likhon</a>
-      </h4>
-      <p><em>Bangla Phonetic Input Engine</em></p>
-      <p>Phonetic input method for typing Bangla from romanized text, combining rule-based transliteration with statistical language modeling. Ships as both a Linux IBus engine and a zero-runtime WebAssembly library.</p>
-      <p>
-        <code>Rust</code> · <code>WebAssembly</code> · <code>NLP</code> · <code>Linux</code> · <code>FSTs</code>
-      </p>
+    <td width="33%" align="center" valign="top">
+      <a href="https://www.brhn.me/projects/likhon">
+        <picture>
+          <source media="(prefers-color-scheme: dark)" srcset="assets/cards/likhon-dark.svg" />
+          <img src="assets/cards/likhon-light.svg" alt="Likhon — Bangla phonetic input engine" width="100%" />
+        </picture>
+      </a>
       <p>
         <a href="https://github.com/brhn-me/likhon">→ Code</a> · <a href="https://www.brhn.me/projects/likhon">→ Details</a>
       </p>
     </td>
-    <td width="33%" valign="top">
-      <h4>
-        <a href="https://www.brhn.me/projects/pipilika">Pipilika</a>
-      </h4>
-      <p><em>First Bangla Search Engine</em></p>
-      <p>Distributed web crawler and custom Bangla content parser (~80% accuracy). Launched in 2013, drew national media attention and became a research platform.</p>
-      <p>
-        <code>Search Engine</code> · <code>Lucene</code> · <code>Hadoop</code> · <code>NLP</code> · <code>Java</code>
-      </p>
+    <td width="33%" align="center" valign="top">
+      <a href="https://www.brhn.me/projects/pipilika">
+        <picture>
+          <source media="(prefers-color-scheme: dark)" srcset="assets/cards/pipilika-dark.svg" />
+          <img src="assets/cards/pipilika-light.svg" alt="Pipilika — first Bangla search engine" width="100%" />
+        </picture>
+      </a>
       <p>
         <a href="https://www.brhn.me/projects/pipilika">→ Details</a>
       </p>
@@ -129,8 +158,15 @@ Full archive on [brhn.me/posts →](https://www.brhn.me/posts)
 
 ### 📊 Activity
 
-<p>
-  <img src="https://github-readme-activity-graph.vercel.app/graph?username=brhn-me&theme=github-compact&hide_border=true&area=true" alt="activity graph" />
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="assets/stats-dark.svg" />
+    <img src="assets/stats-light.svg" alt="GitHub stats" height="170" />
+  </picture>
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="assets/langs-dark.svg" />
+    <img src="assets/langs-light.svg" alt="Top languages" height="170" />
+  </picture>
 </p>
 
 ---
@@ -142,4 +178,11 @@ Full archive on [brhn.me/posts →](https://www.brhn.me/posts)
     <a href="https://www.brhn.me/posts">writing</a> &nbsp;·&nbsp;
     <a href="https://www.brhn.me/projects">projects</a>
   </sub>
+</p>
+
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="assets/footer-dark.svg" />
+    <img src="assets/footer-light.svg" alt="" width="100%" />
+  </picture>
 </p>

--- a/assets/cards/fotu-dark.svg
+++ b/assets/cards/fotu-dark.svg
@@ -1,0 +1,34 @@
+<svg width="420" height="200" viewBox="0 0 420 200" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Fotu — photo organization and deduplication suite">
+  <defs>
+    <linearGradient id="border" x1="0" y1="0" x2="420" y2="200" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#1f6feb"/>
+      <stop offset="1" stop-color="#58a6ff" stop-opacity="0.35"/>
+    </linearGradient>
+    <clipPath id="round">
+      <rect x="1" y="1" width="418" height="198" rx="14"/>
+    </clipPath>
+  </defs>
+  <g font-family="system-ui, -apple-system, 'Segoe UI', sans-serif">
+    <animate attributeName="opacity" from="0" to="1" dur="0.8s" fill="freeze"/>
+    <rect x="1" y="1" width="418" height="198" rx="14" fill="#0d1117" stroke="url(#border)" stroke-width="1.5"/>
+    <g clip-path="url(#round)">
+      <circle cx="420" cy="0" r="130" fill="#1f6feb" opacity="0.08"/>
+    </g>
+    <text x="24" y="42" font-size="22" font-weight="700" fill="#e6edf3">Fotu</text>
+    <text x="24" y="66" font-size="13" font-style="italic" fill="#58a6ff">Photo organization &amp; deduplication suite</text>
+    <text x="24" y="94" font-size="12" fill="#8b949e">Device sync with EXIF-based organization and multi-method</text>
+    <text x="24" y="112" font-size="12" fill="#8b949e">dedup — exact, perceptual, video, CNN. Originals never touched.</text>
+    <g font-size="11" text-anchor="middle">
+      <rect x="24" y="148" width="54" height="24" rx="12" fill="#1f6feb" fill-opacity="0.13" stroke="#1f6feb" stroke-opacity="0.35"/>
+      <text x="51" y="164" fill="#79c0ff">Python</text>
+      <rect x="86" y="148" width="30" height="24" rx="12" fill="#1f6feb" fill-opacity="0.13" stroke="#1f6feb" stroke-opacity="0.35"/>
+      <text x="101" y="164" fill="#79c0ff">Go</text>
+      <rect x="124" y="148" width="48" height="24" rx="12" fill="#1f6feb" fill-opacity="0.13" stroke="#1f6feb" stroke-opacity="0.35"/>
+      <text x="148" y="164" fill="#79c0ff">React</text>
+      <rect x="180" y="148" width="48" height="24" rx="12" fill="#1f6feb" fill-opacity="0.13" stroke="#1f6feb" stroke-opacity="0.35"/>
+      <text x="204" y="164" fill="#79c0ff">Tauri</text>
+      <rect x="236" y="148" width="108" height="24" rx="12" fill="#1f6feb" fill-opacity="0.13" stroke="#1f6feb" stroke-opacity="0.35"/>
+      <text x="290" y="164" fill="#79c0ff">Computer Vision</text>
+    </g>
+  </g>
+</svg>

--- a/assets/cards/fotu-light.svg
+++ b/assets/cards/fotu-light.svg
@@ -1,0 +1,34 @@
+<svg width="420" height="200" viewBox="0 0 420 200" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Fotu — photo organization and deduplication suite">
+  <defs>
+    <linearGradient id="border" x1="0" y1="0" x2="420" y2="200" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#0969da"/>
+      <stop offset="1" stop-color="#54aeff" stop-opacity="0.35"/>
+    </linearGradient>
+    <clipPath id="round">
+      <rect x="1" y="1" width="418" height="198" rx="14"/>
+    </clipPath>
+  </defs>
+  <g font-family="system-ui, -apple-system, 'Segoe UI', sans-serif">
+    <animate attributeName="opacity" from="0" to="1" dur="0.8s" fill="freeze"/>
+    <rect x="1" y="1" width="418" height="198" rx="14" fill="#ffffff" stroke="url(#border)" stroke-width="1.5"/>
+    <g clip-path="url(#round)">
+      <circle cx="420" cy="0" r="130" fill="#54aeff" opacity="0.09"/>
+    </g>
+    <text x="24" y="42" font-size="22" font-weight="700" fill="#1f2328">Fotu</text>
+    <text x="24" y="66" font-size="13" font-style="italic" fill="#0969da">Photo organization &amp; deduplication suite</text>
+    <text x="24" y="94" font-size="12" fill="#57606a">Device sync with EXIF-based organization and multi-method</text>
+    <text x="24" y="112" font-size="12" fill="#57606a">dedup — exact, perceptual, video, CNN. Originals never touched.</text>
+    <g font-size="11" text-anchor="middle">
+      <rect x="24" y="148" width="54" height="24" rx="12" fill="#0969da" fill-opacity="0.07" stroke="#0969da" stroke-opacity="0.3"/>
+      <text x="51" y="164" fill="#0969da">Python</text>
+      <rect x="86" y="148" width="30" height="24" rx="12" fill="#0969da" fill-opacity="0.07" stroke="#0969da" stroke-opacity="0.3"/>
+      <text x="101" y="164" fill="#0969da">Go</text>
+      <rect x="124" y="148" width="48" height="24" rx="12" fill="#0969da" fill-opacity="0.07" stroke="#0969da" stroke-opacity="0.3"/>
+      <text x="148" y="164" fill="#0969da">React</text>
+      <rect x="180" y="148" width="48" height="24" rx="12" fill="#0969da" fill-opacity="0.07" stroke="#0969da" stroke-opacity="0.3"/>
+      <text x="204" y="164" fill="#0969da">Tauri</text>
+      <rect x="236" y="148" width="108" height="24" rx="12" fill="#0969da" fill-opacity="0.07" stroke="#0969da" stroke-opacity="0.3"/>
+      <text x="290" y="164" fill="#0969da">Computer Vision</text>
+    </g>
+  </g>
+</svg>

--- a/assets/cards/likhon-dark.svg
+++ b/assets/cards/likhon-dark.svg
@@ -1,0 +1,34 @@
+<svg width="420" height="200" viewBox="0 0 420 200" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Likhon — Bangla phonetic input engine">
+  <defs>
+    <linearGradient id="border" x1="0" y1="0" x2="420" y2="200" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#1f6feb"/>
+      <stop offset="1" stop-color="#58a6ff" stop-opacity="0.35"/>
+    </linearGradient>
+    <clipPath id="round">
+      <rect x="1" y="1" width="418" height="198" rx="14"/>
+    </clipPath>
+  </defs>
+  <g font-family="system-ui, -apple-system, 'Segoe UI', sans-serif">
+    <animate attributeName="opacity" from="0" to="1" dur="0.8s" fill="freeze"/>
+    <rect x="1" y="1" width="418" height="198" rx="14" fill="#0d1117" stroke="url(#border)" stroke-width="1.5"/>
+    <g clip-path="url(#round)">
+      <circle cx="420" cy="0" r="130" fill="#1f6feb" opacity="0.08"/>
+    </g>
+    <text x="24" y="42" font-size="22" font-weight="700" fill="#e6edf3">Likhon</text>
+    <text x="24" y="66" font-size="13" font-style="italic" fill="#58a6ff">Bangla phonetic input engine</text>
+    <text x="24" y="94" font-size="12" fill="#8b949e">Type Bangla from romanized text — rule-based transliteration</text>
+    <text x="24" y="112" font-size="12" fill="#8b949e">with statistical LM. Ships as an IBus engine and a WASM library.</text>
+    <g font-size="11" text-anchor="middle">
+      <rect x="24" y="148" width="42" height="24" rx="12" fill="#1f6feb" fill-opacity="0.13" stroke="#1f6feb" stroke-opacity="0.35"/>
+      <text x="45" y="164" fill="#79c0ff">Rust</text>
+      <rect x="74" y="148" width="84" height="24" rx="12" fill="#1f6feb" fill-opacity="0.13" stroke="#1f6feb" stroke-opacity="0.35"/>
+      <text x="116" y="164" fill="#79c0ff">WebAssembly</text>
+      <rect x="166" y="148" width="36" height="24" rx="12" fill="#1f6feb" fill-opacity="0.13" stroke="#1f6feb" stroke-opacity="0.35"/>
+      <text x="184" y="164" fill="#79c0ff">NLP</text>
+      <rect x="210" y="148" width="48" height="24" rx="12" fill="#1f6feb" fill-opacity="0.13" stroke="#1f6feb" stroke-opacity="0.35"/>
+      <text x="234" y="164" fill="#79c0ff">Linux</text>
+      <rect x="266" y="148" width="42" height="24" rx="12" fill="#1f6feb" fill-opacity="0.13" stroke="#1f6feb" stroke-opacity="0.35"/>
+      <text x="287" y="164" fill="#79c0ff">FSTs</text>
+    </g>
+  </g>
+</svg>

--- a/assets/cards/likhon-light.svg
+++ b/assets/cards/likhon-light.svg
@@ -1,0 +1,34 @@
+<svg width="420" height="200" viewBox="0 0 420 200" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Likhon — Bangla phonetic input engine">
+  <defs>
+    <linearGradient id="border" x1="0" y1="0" x2="420" y2="200" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#0969da"/>
+      <stop offset="1" stop-color="#54aeff" stop-opacity="0.35"/>
+    </linearGradient>
+    <clipPath id="round">
+      <rect x="1" y="1" width="418" height="198" rx="14"/>
+    </clipPath>
+  </defs>
+  <g font-family="system-ui, -apple-system, 'Segoe UI', sans-serif">
+    <animate attributeName="opacity" from="0" to="1" dur="0.8s" fill="freeze"/>
+    <rect x="1" y="1" width="418" height="198" rx="14" fill="#ffffff" stroke="url(#border)" stroke-width="1.5"/>
+    <g clip-path="url(#round)">
+      <circle cx="420" cy="0" r="130" fill="#54aeff" opacity="0.09"/>
+    </g>
+    <text x="24" y="42" font-size="22" font-weight="700" fill="#1f2328">Likhon</text>
+    <text x="24" y="66" font-size="13" font-style="italic" fill="#0969da">Bangla phonetic input engine</text>
+    <text x="24" y="94" font-size="12" fill="#57606a">Type Bangla from romanized text — rule-based transliteration</text>
+    <text x="24" y="112" font-size="12" fill="#57606a">with statistical LM. Ships as an IBus engine and a WASM library.</text>
+    <g font-size="11" text-anchor="middle">
+      <rect x="24" y="148" width="42" height="24" rx="12" fill="#0969da" fill-opacity="0.07" stroke="#0969da" stroke-opacity="0.3"/>
+      <text x="45" y="164" fill="#0969da">Rust</text>
+      <rect x="74" y="148" width="84" height="24" rx="12" fill="#0969da" fill-opacity="0.07" stroke="#0969da" stroke-opacity="0.3"/>
+      <text x="116" y="164" fill="#0969da">WebAssembly</text>
+      <rect x="166" y="148" width="36" height="24" rx="12" fill="#0969da" fill-opacity="0.07" stroke="#0969da" stroke-opacity="0.3"/>
+      <text x="184" y="164" fill="#0969da">NLP</text>
+      <rect x="210" y="148" width="48" height="24" rx="12" fill="#0969da" fill-opacity="0.07" stroke="#0969da" stroke-opacity="0.3"/>
+      <text x="234" y="164" fill="#0969da">Linux</text>
+      <rect x="266" y="148" width="42" height="24" rx="12" fill="#0969da" fill-opacity="0.07" stroke="#0969da" stroke-opacity="0.3"/>
+      <text x="287" y="164" fill="#0969da">FSTs</text>
+    </g>
+  </g>
+</svg>

--- a/assets/cards/pipilika-dark.svg
+++ b/assets/cards/pipilika-dark.svg
@@ -1,0 +1,34 @@
+<svg width="420" height="200" viewBox="0 0 420 200" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Pipilika — first Bangla search engine">
+  <defs>
+    <linearGradient id="border" x1="0" y1="0" x2="420" y2="200" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#1f6feb"/>
+      <stop offset="1" stop-color="#58a6ff" stop-opacity="0.35"/>
+    </linearGradient>
+    <clipPath id="round">
+      <rect x="1" y="1" width="418" height="198" rx="14"/>
+    </clipPath>
+  </defs>
+  <g font-family="system-ui, -apple-system, 'Segoe UI', sans-serif">
+    <animate attributeName="opacity" from="0" to="1" dur="0.8s" fill="freeze"/>
+    <rect x="1" y="1" width="418" height="198" rx="14" fill="#0d1117" stroke="url(#border)" stroke-width="1.5"/>
+    <g clip-path="url(#round)">
+      <circle cx="420" cy="0" r="130" fill="#1f6feb" opacity="0.08"/>
+    </g>
+    <text x="24" y="42" font-size="22" font-weight="700" fill="#e6edf3">Pipilika</text>
+    <text x="24" y="66" font-size="13" font-style="italic" fill="#58a6ff">First Bangla search engine</text>
+    <text x="24" y="94" font-size="12" fill="#8b949e">Distributed crawler and custom Bangla parser (~80% accuracy).</text>
+    <text x="24" y="112" font-size="12" fill="#8b949e">Launched 2013 — national media attention, research platform.</text>
+    <g font-size="11" text-anchor="middle">
+      <rect x="24" y="148" width="42" height="24" rx="12" fill="#1f6feb" fill-opacity="0.13" stroke="#1f6feb" stroke-opacity="0.35"/>
+      <text x="45" y="164" fill="#79c0ff">Java</text>
+      <rect x="74" y="148" width="54" height="24" rx="12" fill="#1f6feb" fill-opacity="0.13" stroke="#1f6feb" stroke-opacity="0.35"/>
+      <text x="101" y="164" fill="#79c0ff">Lucene</text>
+      <rect x="136" y="148" width="54" height="24" rx="12" fill="#1f6feb" fill-opacity="0.13" stroke="#1f6feb" stroke-opacity="0.35"/>
+      <text x="163" y="164" fill="#79c0ff">Hadoop</text>
+      <rect x="198" y="148" width="36" height="24" rx="12" fill="#1f6feb" fill-opacity="0.13" stroke="#1f6feb" stroke-opacity="0.35"/>
+      <text x="216" y="164" fill="#79c0ff">NLP</text>
+      <rect x="242" y="148" width="54" height="24" rx="12" fill="#1f6feb" fill-opacity="0.13" stroke="#1f6feb" stroke-opacity="0.35"/>
+      <text x="269" y="164" fill="#79c0ff">Search</text>
+    </g>
+  </g>
+</svg>

--- a/assets/cards/pipilika-light.svg
+++ b/assets/cards/pipilika-light.svg
@@ -1,0 +1,34 @@
+<svg width="420" height="200" viewBox="0 0 420 200" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Pipilika — first Bangla search engine">
+  <defs>
+    <linearGradient id="border" x1="0" y1="0" x2="420" y2="200" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#0969da"/>
+      <stop offset="1" stop-color="#54aeff" stop-opacity="0.35"/>
+    </linearGradient>
+    <clipPath id="round">
+      <rect x="1" y="1" width="418" height="198" rx="14"/>
+    </clipPath>
+  </defs>
+  <g font-family="system-ui, -apple-system, 'Segoe UI', sans-serif">
+    <animate attributeName="opacity" from="0" to="1" dur="0.8s" fill="freeze"/>
+    <rect x="1" y="1" width="418" height="198" rx="14" fill="#ffffff" stroke="url(#border)" stroke-width="1.5"/>
+    <g clip-path="url(#round)">
+      <circle cx="420" cy="0" r="130" fill="#54aeff" opacity="0.09"/>
+    </g>
+    <text x="24" y="42" font-size="22" font-weight="700" fill="#1f2328">Pipilika</text>
+    <text x="24" y="66" font-size="13" font-style="italic" fill="#0969da">First Bangla search engine</text>
+    <text x="24" y="94" font-size="12" fill="#57606a">Distributed crawler and custom Bangla parser (~80% accuracy).</text>
+    <text x="24" y="112" font-size="12" fill="#57606a">Launched 2013 — national media attention, research platform.</text>
+    <g font-size="11" text-anchor="middle">
+      <rect x="24" y="148" width="42" height="24" rx="12" fill="#0969da" fill-opacity="0.07" stroke="#0969da" stroke-opacity="0.3"/>
+      <text x="45" y="164" fill="#0969da">Java</text>
+      <rect x="74" y="148" width="54" height="24" rx="12" fill="#0969da" fill-opacity="0.07" stroke="#0969da" stroke-opacity="0.3"/>
+      <text x="101" y="164" fill="#0969da">Lucene</text>
+      <rect x="136" y="148" width="54" height="24" rx="12" fill="#0969da" fill-opacity="0.07" stroke="#0969da" stroke-opacity="0.3"/>
+      <text x="163" y="164" fill="#0969da">Hadoop</text>
+      <rect x="198" y="148" width="36" height="24" rx="12" fill="#0969da" fill-opacity="0.07" stroke="#0969da" stroke-opacity="0.3"/>
+      <text x="216" y="164" fill="#0969da">NLP</text>
+      <rect x="242" y="148" width="54" height="24" rx="12" fill="#0969da" fill-opacity="0.07" stroke="#0969da" stroke-opacity="0.3"/>
+      <text x="269" y="164" fill="#0969da">Search</text>
+    </g>
+  </g>
+</svg>

--- a/assets/footer-dark.svg
+++ b/assets/footer-dark.svg
@@ -1,0 +1,23 @@
+<svg width="850" height="110" viewBox="0 0 850 110" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="">
+  <defs>
+    <linearGradient id="w1" x1="0" y1="30" x2="850" y2="110" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#1f6feb" stop-opacity="0.45"/>
+      <stop offset="1" stop-color="#58a6ff" stop-opacity="0.16"/>
+    </linearGradient>
+    <linearGradient id="w2" x1="0" y1="50" x2="850" y2="110" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#58a6ff" stop-opacity="0.25"/>
+      <stop offset="1" stop-color="#1f6feb" stop-opacity="0.08"/>
+    </linearGradient>
+    <clipPath id="round">
+      <rect width="850" height="110" rx="14"/>
+    </clipPath>
+  </defs>
+  <g clip-path="url(#round)">
+    <path d="M0 44 Q106.25 20 212.5 44 T425 44 T637.5 44 T850 44 T1062.5 44 T1275 44 T1487.5 44 T1700 44 V111 H0 Z" fill="url(#w1)">
+      <animateTransform attributeName="transform" type="translate" from="0 0" to="-850 0" dur="26s" repeatCount="indefinite"/>
+    </path>
+    <path d="M0 62 Q106.25 80 212.5 62 T425 62 T637.5 62 T850 62 T1062.5 62 T1275 62 T1487.5 62 T1700 62 V111 H0 Z" fill="url(#w2)">
+      <animateTransform attributeName="transform" type="translate" from="-850 0" to="0 0" dur="19s" repeatCount="indefinite"/>
+    </path>
+  </g>
+</svg>

--- a/assets/footer-light.svg
+++ b/assets/footer-light.svg
@@ -1,0 +1,23 @@
+<svg width="850" height="110" viewBox="0 0 850 110" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="">
+  <defs>
+    <linearGradient id="w1" x1="0" y1="30" x2="850" y2="110" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#0969da" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#54aeff" stop-opacity="0.10"/>
+    </linearGradient>
+    <linearGradient id="w2" x1="0" y1="50" x2="850" y2="110" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#54aeff" stop-opacity="0.18"/>
+      <stop offset="1" stop-color="#0969da" stop-opacity="0.06"/>
+    </linearGradient>
+    <clipPath id="round">
+      <rect width="850" height="110" rx="14"/>
+    </clipPath>
+  </defs>
+  <g clip-path="url(#round)">
+    <path d="M0 44 Q106.25 20 212.5 44 T425 44 T637.5 44 T850 44 T1062.5 44 T1275 44 T1487.5 44 T1700 44 V111 H0 Z" fill="url(#w1)">
+      <animateTransform attributeName="transform" type="translate" from="0 0" to="-850 0" dur="26s" repeatCount="indefinite"/>
+    </path>
+    <path d="M0 62 Q106.25 80 212.5 62 T425 62 T637.5 62 T850 62 T1062.5 62 T1275 62 T1487.5 62 T1700 62 V111 H0 Z" fill="url(#w2)">
+      <animateTransform attributeName="transform" type="translate" from="-850 0" to="0 0" dur="19s" repeatCount="indefinite"/>
+    </path>
+  </g>
+</svg>

--- a/assets/header-dark.svg
+++ b/assets/header-dark.svg
@@ -1,0 +1,39 @@
+<svg width="850" height="220" viewBox="0 0 850 220" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="@brhn-me — AI, full-stack engineering, distributed systems">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="850" y2="220" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#0d1117"/>
+      <stop offset="1" stop-color="#101a2e"/>
+    </linearGradient>
+    <linearGradient id="w1" x1="0" y1="140" x2="850" y2="220" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#1f6feb" stop-opacity="0.55"/>
+      <stop offset="1" stop-color="#58a6ff" stop-opacity="0.22"/>
+    </linearGradient>
+    <linearGradient id="w2" x1="0" y1="160" x2="850" y2="220" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#58a6ff" stop-opacity="0.30"/>
+      <stop offset="1" stop-color="#1f6feb" stop-opacity="0.12"/>
+    </linearGradient>
+    <clipPath id="round">
+      <rect width="850" height="220" rx="14"/>
+    </clipPath>
+  </defs>
+  <g clip-path="url(#round)">
+    <rect width="850" height="220" fill="url(#bg)"/>
+    <circle cx="425" cy="30" r="280" fill="#1f6feb">
+      <animate attributeName="opacity" values="0.06;0.13;0.06" dur="9s" repeatCount="indefinite"/>
+    </circle>
+    <path d="M0 168 Q106.25 142 212.5 168 T425 168 T637.5 168 T850 168 T1062.5 168 T1275 168 T1487.5 168 T1700 168 V221 H0 Z" fill="url(#w1)">
+      <animateTransform attributeName="transform" type="translate" from="0 0" to="-850 0" dur="26s" repeatCount="indefinite"/>
+    </path>
+    <path d="M0 186 Q106.25 206 212.5 186 T425 186 T637.5 186 T850 186 T1062.5 186 T1275 186 T1487.5 186 T1700 186 V221 H0 Z" fill="url(#w2)">
+      <animateTransform attributeName="transform" type="translate" from="-850 0" to="0 0" dur="19s" repeatCount="indefinite"/>
+    </path>
+    <text x="425" y="102" text-anchor="middle" font-family="system-ui, -apple-system, 'Segoe UI', sans-serif" font-size="46" font-weight="700" letter-spacing="1.5" fill="#e6edf3" opacity="0">
+      @brhn-me
+      <animate attributeName="opacity" from="0" to="1" begin="0.15s" dur="1.1s" fill="freeze"/>
+    </text>
+    <text x="425" y="134" text-anchor="middle" font-family="system-ui, -apple-system, 'Segoe UI', sans-serif" font-size="15" letter-spacing="0.5" fill="#8b949e" opacity="0">
+      brhn.me — AI · full-stack engineering · distributed systems
+      <animate attributeName="opacity" from="0" to="1" begin="0.7s" dur="1.1s" fill="freeze"/>
+    </text>
+  </g>
+</svg>

--- a/assets/header-light.svg
+++ b/assets/header-light.svg
@@ -1,0 +1,39 @@
+<svg width="850" height="220" viewBox="0 0 850 220" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="@brhn-me — AI, full-stack engineering, distributed systems">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="850" y2="220" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#f6f8fa"/>
+      <stop offset="1" stop-color="#e7f0fb"/>
+    </linearGradient>
+    <linearGradient id="w1" x1="0" y1="140" x2="850" y2="220" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#0969da" stop-opacity="0.30"/>
+      <stop offset="1" stop-color="#54aeff" stop-opacity="0.14"/>
+    </linearGradient>
+    <linearGradient id="w2" x1="0" y1="160" x2="850" y2="220" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#54aeff" stop-opacity="0.22"/>
+      <stop offset="1" stop-color="#0969da" stop-opacity="0.08"/>
+    </linearGradient>
+    <clipPath id="round">
+      <rect width="850" height="220" rx="14"/>
+    </clipPath>
+  </defs>
+  <g clip-path="url(#round)">
+    <rect width="850" height="220" fill="url(#bg)"/>
+    <circle cx="425" cy="30" r="280" fill="#54aeff">
+      <animate attributeName="opacity" values="0.05;0.11;0.05" dur="9s" repeatCount="indefinite"/>
+    </circle>
+    <path d="M0 168 Q106.25 142 212.5 168 T425 168 T637.5 168 T850 168 T1062.5 168 T1275 168 T1487.5 168 T1700 168 V221 H0 Z" fill="url(#w1)">
+      <animateTransform attributeName="transform" type="translate" from="0 0" to="-850 0" dur="26s" repeatCount="indefinite"/>
+    </path>
+    <path d="M0 186 Q106.25 206 212.5 186 T425 186 T637.5 186 T850 186 T1062.5 186 T1275 186 T1487.5 186 T1700 186 V221 H0 Z" fill="url(#w2)">
+      <animateTransform attributeName="transform" type="translate" from="-850 0" to="0 0" dur="19s" repeatCount="indefinite"/>
+    </path>
+    <text x="425" y="102" text-anchor="middle" font-family="system-ui, -apple-system, 'Segoe UI', sans-serif" font-size="46" font-weight="700" letter-spacing="1.5" fill="#1f2328" opacity="0">
+      @brhn-me
+      <animate attributeName="opacity" from="0" to="1" begin="0.15s" dur="1.1s" fill="freeze"/>
+    </text>
+    <text x="425" y="134" text-anchor="middle" font-family="system-ui, -apple-system, 'Segoe UI', sans-serif" font-size="15" letter-spacing="0.5" fill="#57606a" opacity="0">
+      brhn.me — AI · full-stack engineering · distributed systems
+      <animate attributeName="opacity" from="0" to="1" begin="0.7s" dur="1.1s" fill="freeze"/>
+    </text>
+  </g>
+</svg>

--- a/assets/langs-dark.svg
+++ b/assets/langs-dark.svg
@@ -1,0 +1,3 @@
+<svg width="420" height="170" viewBox="0 0 420 170" xmlns="http://www.w3.org/2000/svg">
+  <text x="210" y="90" text-anchor="middle" font-family="system-ui, sans-serif" font-size="13" fill="#8b949e">refreshing…</text>
+</svg>

--- a/assets/langs-light.svg
+++ b/assets/langs-light.svg
@@ -1,0 +1,3 @@
+<svg width="420" height="170" viewBox="0 0 420 170" xmlns="http://www.w3.org/2000/svg">
+  <text x="210" y="90" text-anchor="middle" font-family="system-ui, sans-serif" font-size="13" fill="#57606a">refreshing…</text>
+</svg>

--- a/assets/stats-dark.svg
+++ b/assets/stats-dark.svg
@@ -1,0 +1,3 @@
+<svg width="420" height="170" viewBox="0 0 420 170" xmlns="http://www.w3.org/2000/svg">
+  <text x="210" y="90" text-anchor="middle" font-family="system-ui, sans-serif" font-size="13" fill="#8b949e">refreshing…</text>
+</svg>

--- a/assets/stats-light.svg
+++ b/assets/stats-light.svg
@@ -1,0 +1,3 @@
+<svg width="420" height="170" viewBox="0 0 420 170" xmlns="http://www.w3.org/2000/svg">
+  <text x="210" y="90" text-anchor="middle" font-family="system-ui, sans-serif" font-size="13" fill="#57606a">refreshing…</text>
+</svg>

--- a/assets/taglines-dark.svg
+++ b/assets/taglines-dark.svg
@@ -1,0 +1,20 @@
+<svg width="850" height="44" viewBox="0 0 850 44" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="AI + full-stack software engineer">
+  <g font-family="system-ui, -apple-system, 'Segoe UI', sans-serif" font-size="18" font-weight="500" text-anchor="middle" fill="#58a6ff">
+    <text x="425" y="28" opacity="0">
+      AI + Full-Stack Software Engineer
+      <animate attributeName="opacity" values="0;1;1;0;0" keyTimes="0;0.05;0.22;0.27;1" dur="16s" begin="0s" repeatCount="indefinite"/>
+    </text>
+    <text x="425" y="28" opacity="0">
+      Currently building: agentic AI systems
+      <animate attributeName="opacity" values="0;1;1;0;0" keyTimes="0;0.05;0.22;0.27;1" dur="16s" begin="4s" repeatCount="indefinite"/>
+    </text>
+    <text x="425" y="28" opacity="0">
+      Java · Spring Boot · Elasticsearch · large-scale data
+      <animate attributeName="opacity" values="0;1;1;0;0" keyTimes="0;0.05;0.22;0.27;1" dur="16s" begin="8s" repeatCount="indefinite"/>
+    </text>
+    <text x="425" y="28" opacity="0">
+      Distributed systems · ML pipelines · NLP
+      <animate attributeName="opacity" values="0;1;1;0;0" keyTimes="0;0.05;0.22;0.27;1" dur="16s" begin="12s" repeatCount="indefinite"/>
+    </text>
+  </g>
+</svg>

--- a/assets/taglines-light.svg
+++ b/assets/taglines-light.svg
@@ -1,0 +1,20 @@
+<svg width="850" height="44" viewBox="0 0 850 44" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="AI + full-stack software engineer">
+  <g font-family="system-ui, -apple-system, 'Segoe UI', sans-serif" font-size="18" font-weight="500" text-anchor="middle" fill="#0969da">
+    <text x="425" y="28" opacity="0">
+      AI + Full-Stack Software Engineer
+      <animate attributeName="opacity" values="0;1;1;0;0" keyTimes="0;0.05;0.22;0.27;1" dur="16s" begin="0s" repeatCount="indefinite"/>
+    </text>
+    <text x="425" y="28" opacity="0">
+      Currently building: agentic AI systems
+      <animate attributeName="opacity" values="0;1;1;0;0" keyTimes="0;0.05;0.22;0.27;1" dur="16s" begin="4s" repeatCount="indefinite"/>
+    </text>
+    <text x="425" y="28" opacity="0">
+      Java · Spring Boot · Elasticsearch · large-scale data
+      <animate attributeName="opacity" values="0;1;1;0;0" keyTimes="0;0.05;0.22;0.27;1" dur="16s" begin="8s" repeatCount="indefinite"/>
+    </text>
+    <text x="425" y="28" opacity="0">
+      Distributed systems · ML pipelines · NLP
+      <animate attributeName="opacity" values="0;1;1;0;0" keyTimes="0;0.05;0.22;0.27;1" dur="16s" begin="12s" repeatCount="indefinite"/>
+    </text>
+  </g>
+</svg>


### PR DESCRIPTION
## What changed

**Reliability — zero live third-party render dependencies left**
- Replaced the capsule-render header and demolab typing SVG with hand-authored animated SVGs (SMIL) committed in `assets/`
- Replaced the Vercel-hosted activity graph with stats + top-langs cards rendered daily in CI by `stats-organization/github-readme-stats-action@v2` and committed to the repo (new `.github/workflows/profile-assets.yml`); placeholder SVGs ship until the first run
- Only remaining external images: skillicons.dev and shields.io (both static, heavily cached)

**Light + dark mode**
- Every visual is wrapped in `<picture>` with `prefers-color-scheme` variants — the page now looks right in both themes (previously the dark wave header and dark icons sat on light backgrounds)

**Visual restructure**
- Custom animated project card SVGs for Fotu, Likhon, Pipilika (consistent design language: navy → `#1f6feb` gradients)
- Skills section condensed from 6 subsections + keyword lists to one themed icon table
- Dropped the komarev profile-views badge; added a Medium badge
- New rotating-tagline SVG and a wave footer bookending the header

**Workflow hygiene**
- Blog workflow: `checkout@v4`, pinned `blog-post-workflow@1.9.6`, `workflow_dispatch`, explicit permissions, richer post template with dates
- Shared `concurrency` group between the two workflows to avoid push races

## After merging
1. Run the **Generate profile assets** workflow once (`gh workflow run profile-assets.yml`) to replace the placeholder stats cards
2. Optionally run the blog workflow to refresh the post list with the new template

## Review tips
- Open the README preview on this branch in both browser/OS themes — `<picture>` follows `prefers-color-scheme`
- Open the SVGs in `assets/` directly to see the animations